### PR TITLE
no-jira nullify active conversationId upon disconnect

### DIFF
--- a/react-app/src/library/services/vendor-implementations/jabra/jabra.test.ts
+++ b/react-app/src/library/services/vendor-implementations/jabra/jabra.test.ts
@@ -699,6 +699,25 @@ describe('JabraService', () => {
       expect(jabraService.callLock).toBe(false);
       expect(connectionSpy).toHaveBeenCalled();
     });
+
+    it('should nullify activeConversationId if one exists upon disconnect', async () => {
+      const deviceSignalsSubject = new Subject<ICallControlSignal>();
+      const connectionSpy = jabraService['changeConnectionStatus'] = jest.fn();
+
+      const callControl = createMockCallControl(deviceSignalsSubject.asObservable());
+
+      jabraService.callControl = callControl as any;
+      jabraService.callLock = true;
+      jabraService.isConnected = true;
+      jabraService.activeConversationId = 'testId123';
+
+      await jabraService.disconnect();
+
+      expect(callControl.releaseCallLock).toHaveBeenCalled();
+      expect(jabraService.callLock).toBe(false);
+      expect(connectionSpy).toHaveBeenCalled();
+      expect(jabraService.activeConversationId).toBeNull();
+    });
   });
 
   describe('answerCall', () => {

--- a/react-app/src/library/services/vendor-implementations/jabra/jabra.ts
+++ b/react-app/src/library/services/vendor-implementations/jabra/jabra.ts
@@ -465,6 +465,10 @@ export default class JabraService extends VendorImplementation {
     } finally {
       this.resetHeadsetState();
       this.callLock = false;
+      /* istanbul ignore next */
+      if (this.activeConversationId) {
+        this.activeConversationId = null;
+      }
       this.headsetEventSubscription && this.headsetEventSubscription.unsubscribe();
       (this.isConnected || this.isConnecting) &&
         this.changeConnectionStatus({ isConnected: false, isConnecting: false });

--- a/react-app/src/library/services/vendor-implementations/jabra/jabra.ts
+++ b/react-app/src/library/services/vendor-implementations/jabra/jabra.ts
@@ -465,7 +465,6 @@ export default class JabraService extends VendorImplementation {
     } finally {
       this.resetHeadsetState();
       this.callLock = false;
-      /* istanbul ignore next */
       if (this.activeConversationId) {
         this.activeConversationId = null;
       }


### PR DESCRIPTION
There was an issue found where `activeConversationId` persisted after a call ended because the device was changed during an active call.  For the time being, nullifying this value on disconnect appears to be the fix but a proper fix I think would involve switching to Jabra's multicall control implementation for Jabra WebHID.

This only seems to affect Jabra for the time being so I only put a change in there but I can do the same for other vendors.