### PR TITLE
HID - Filter with specific vendor and product id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 coverage/
 tmp/
 softphone-vendor-headsets*.tgz
+.history/

--- a/react-app/src/library/services/vendor-implementations/CyberAcoustics/CyberAcoustics.ts
+++ b/react-app/src/library/services/vendor-implementations/CyberAcoustics/CyberAcoustics.ts
@@ -169,7 +169,7 @@ export default class CyberAcousticsService extends VendorImplementation {
                 {
                   vendorId: 0x3391,
                   //vendorId: 0x046D,
-                  productId
+                  productId: productId || undefined
                 },
               ],
             });

--- a/react-app/src/library/services/vendor-implementations/CyberAcoustics/CyberAcoustics.ts
+++ b/react-app/src/library/services/vendor-implementations/CyberAcoustics/CyberAcoustics.ts
@@ -163,11 +163,13 @@ export default class CyberAcousticsService extends VendorImplementation {
           const HIDPermissionTimeout = setTimeout(reject, 30000);
           this.requestWebHidPermissions(async () => {
             this.logger.debug("Requesting web HID permissions");
+            const productId = this.deductProductId(originalDeviceLabel);
             const devList = await  (window.navigator as any).hid.requestDevice({
               filters: [
                 {
                   vendorId: 0x3391,
                   //vendorId: 0x046D,
+                  productId
                 },
               ],
             });
@@ -336,7 +338,7 @@ export default class CyberAcousticsService extends VendorImplementation {
       }
 
       ////
-      this.activeDevice.removeEventListener('inputreport', this.handleInputReport); 
+      this.activeDevice.removeEventListener('inputreport', this.handleInputReport);
       this.numDeviceEventListeners--;
       console.debug(`Removed Device Input listener, num listeners = ${this.numDeviceEventListeners} `);
       ////
@@ -676,7 +678,7 @@ export default class CyberAcousticsService extends VendorImplementation {
     }
     ////this.logger.debug(`CA: Command assembled: ${this.gCmdBuf[0].toString(16)},  ${this.gCmdBuf[1].toString(16)} `);
     ////this.logger.debug(`CA: reportID ${this.headsetOutputReportId.toString(16)} `);
-    await this.activeDevice.sendReport(this.headsetOutputReportId, this.gCmdBuf ); 
+    await this.activeDevice.sendReport(this.headsetOutputReportId, this.gCmdBuf );
     this.logger.debug(`CA: Sent Command to Device. Value: ${ this.formatHex(this.gCmdBuf[0])},  ${ this.formatHex(this.gCmdBuf[1])} `);
 
     this.gCmdBuf[0] = 0;

--- a/react-app/src/library/services/vendor-implementations/vbet/vbet.ts
+++ b/react-app/src/library/services/vendor-implementations/vbet/vbet.ts
@@ -111,7 +111,8 @@ export default class VBetService extends VendorImplementation {
         this.activeDevice = await new Promise((resolve, reject) => {
           const waiter = setTimeout(reject, 30000);
           this.requestWebHidPermissions(async () => {
-            const filters = [{ usage: HEADSET_USAGE, usagePage: HEADSET_USAGE_PAGE, vendorId: VENDOR_ID }];
+            const productId = this.deductProductId(originalDeviceLabel);
+            const filters = [{ usage: HEADSET_USAGE, usagePage: HEADSET_USAGE_PAGE, vendorId: VENDOR_ID, productId }];
             await (window.navigator as any).hid.requestDevice({ filters });
             clearTimeout(waiter);
             const deviceList = await (window.navigator as any).hid.getDevices();

--- a/react-app/src/library/services/vendor-implementations/vbet/vbet.ts
+++ b/react-app/src/library/services/vendor-implementations/vbet/vbet.ts
@@ -6,6 +6,7 @@ import { isCefHosted } from '../../../utils';
 
 const HEADSET_USAGE = 0x0005;
 const HEADSET_USAGE_PAGE = 0x000b;
+const VENDOR_ID = 0x340b;
 const BT100USeries = [0x0001];
 const CMEDIASeries = [0x0020, 0x0022];
 const DECTSeries = [0x0014];
@@ -110,7 +111,7 @@ export default class VBetService extends VendorImplementation {
         this.activeDevice = await new Promise((resolve, reject) => {
           const waiter = setTimeout(reject, 30000);
           this.requestWebHidPermissions(async () => {
-            const filters = [{ usage: HEADSET_USAGE, usagePage: HEADSET_USAGE_PAGE }];
+            const filters = [{ usage: HEADSET_USAGE, usagePage: HEADSET_USAGE_PAGE, vendorId: VENDOR_ID }];
             await (window.navigator as any).hid.requestDevice({ filters });
             clearTimeout(waiter);
             const deviceList = await (window.navigator as any).hid.getDevices();
@@ -143,9 +144,9 @@ export default class VBetService extends VendorImplementation {
       }
     }
 
-   
+
     !this.activeDevice.opened && await this.activeDevice.open();
-    
+
 
     this.logger.debug(`device input reportId ${this.inputReportReportId}`);
     this.activeDevice.addEventListener('inputreport', (event: PartialInputReportEvent) => {
@@ -214,7 +215,7 @@ export default class VBetService extends VendorImplementation {
         await this.setMuteFromDevice(!this.isMuted);
         break;
       }
-    } 
+    }
     if (this.activeDevice.productId >= 0x0040 && this.activeDevice.productId <= 0x0083) {
       switch (value) {
       case 0x20:
@@ -323,7 +324,7 @@ export default class VBetService extends VendorImplementation {
         await this.sendOpToDevice('onHook');
       } else {
         this.logger.error('no call to be ended');
-      } 
+      }
     }
   }
 

--- a/react-app/src/library/services/vendor-implementations/vbet/vbet.ts
+++ b/react-app/src/library/services/vendor-implementations/vbet/vbet.ts
@@ -112,7 +112,7 @@ export default class VBetService extends VendorImplementation {
           const waiter = setTimeout(reject, 30000);
           this.requestWebHidPermissions(async () => {
             const productId = this.deductProductId(originalDeviceLabel);
-            const filters = [{ usage: HEADSET_USAGE, usagePage: HEADSET_USAGE_PAGE, vendorId: VENDOR_ID, productId }];
+            const filters = [{ usage: HEADSET_USAGE, usagePage: HEADSET_USAGE_PAGE, vendorId: VENDOR_ID, productId: productId || undefined }];
             await (window.navigator as any).hid.requestDevice({ filters });
             clearTimeout(waiter);
             const deviceList = await (window.navigator as any).hid.getDevices();

--- a/react-app/src/library/services/vendor-implementations/vendor-implementation.ts
+++ b/react-app/src/library/services/vendor-implementations/vendor-implementation.ts
@@ -138,4 +138,16 @@ export abstract class VendorImplementation extends (EventEmitter as { new(): Str
     this.isConnecting = headsetState.isConnecting;
     this.emitEvent('deviceConnectionStatusChanged', { currentVendor: this, ...headsetState });
   }
+
+  /**
+   * Try to deduct the product id based on the label.
+   * Making the assumption that the label will end with (vendorid:productid).
+   *
+   * @param selectedMicLabel
+   * @returns The product id if matched or null.
+   */
+  deductProductId (selectedMicLabel: string) : string {
+    const match = selectedMicLabel?.match(/\((\w+):(\w+)\)$/);
+    return match ? match[2] : null;
+  }
 }

--- a/react-app/src/library/services/vendor-implementations/vendor-implementation.ts
+++ b/react-app/src/library/services/vendor-implementations/vendor-implementation.ts
@@ -146,8 +146,8 @@ export abstract class VendorImplementation extends (EventEmitter as { new(): Str
    * @param selectedMicLabel
    * @returns The product id if matched or null.
    */
-  deductProductId (selectedMicLabel: string) : string {
+  deductProductId (selectedMicLabel: string) : number {
     const match = selectedMicLabel?.match(/\((\w+):(\w+)\)$/);
-    return match ? match[2] : null;
+    return match ? parseInt(match[2], 16) : null;
   }
 }

--- a/react-app/src/library/services/vendor-implementations/vendor-implemntation.test.ts
+++ b/react-app/src/library/services/vendor-implementations/vendor-implemntation.test.ts
@@ -121,3 +121,16 @@ describe('resetHeadsetStateForCall', () => {
     expect(rejectSpy).toHaveBeenCalledWith('test123');
   });
 });
+
+describe('deductProductId', () => {
+  it('should match proper labels', () => {
+    const result = implementation.deductProductId('Test Device Label (6993:123)');
+    expect(result).toBe('123');
+  });
+
+  it('should not match invalid labels', () => {
+    const result = implementation.deductProductId('Test Device Label');
+    expect(result).toBe(null);
+  });
+});
+

--- a/react-app/src/library/services/vendor-implementations/vendor-implemntation.test.ts
+++ b/react-app/src/library/services/vendor-implementations/vendor-implemntation.test.ts
@@ -124,8 +124,8 @@ describe('resetHeadsetStateForCall', () => {
 
 describe('deductProductId', () => {
   it('should match proper labels', () => {
-    const result = implementation.deductProductId('Test Device Label (6993:123)');
-    expect(result).toBe('123');
+    const result = implementation.deductProductId('Test Device Label (6993:b017)');
+    expect(result).toBe(45079);
   });
 
   it('should not match invalid labels', () => {

--- a/react-app/src/library/services/vendor-implementations/yealink/yealink.ts
+++ b/react-app/src/library/services/vendor-implementations/yealink/yealink.ts
@@ -81,7 +81,8 @@ export default class YealinkService extends VendorImplementation {
         this.activeDevice = await new Promise((resolve, reject) => {
           const waiter = setTimeout(reject, 30000);
           this.requestWebHidPermissions(async () => {
-            const filters = [{ usage: HEADSET_USAGE, usagePage: HEADSET_USAGE_PAGE, vendorId: VENDOR_ID }];
+            const productId = this.deductProductId(originalDeviceLabel);
+            const filters = [{ usage: HEADSET_USAGE, usagePage: HEADSET_USAGE_PAGE, vendorId: VENDOR_ID, productId }];
             await (window.navigator as any).hid.requestDevice({ filters });
             clearTimeout(waiter);
             const deviceLists: PartialHIDDevice[] = await (window.navigator as any).hid.getDevices();

--- a/react-app/src/library/services/vendor-implementations/yealink/yealink.ts
+++ b/react-app/src/library/services/vendor-implementations/yealink/yealink.ts
@@ -12,6 +12,7 @@ const recMuteFlag = 0b100;
 const recReject = 0x40;
 const HEADSET_USAGE = 0x0005;
 const HEADSET_USAGE_PAGE = 0x000B;
+const VENDOR_ID = 0x6993;
 
 export default class YealinkService extends VendorImplementation {
   private static instance: YealinkService;
@@ -80,7 +81,7 @@ export default class YealinkService extends VendorImplementation {
         this.activeDevice = await new Promise((resolve, reject) => {
           const waiter = setTimeout(reject, 30000);
           this.requestWebHidPermissions(async () => {
-            const filters = [{ usage: HEADSET_USAGE, usagePage: HEADSET_USAGE_PAGE }];
+            const filters = [{ usage: HEADSET_USAGE, usagePage: HEADSET_USAGE_PAGE, vendorId: VENDOR_ID }];
             await (window.navigator as any).hid.requestDevice({ filters });
             clearTimeout(waiter);
             const deviceLists: PartialHIDDevice[] = await (window.navigator as any).hid.getDevices();

--- a/react-app/src/library/services/vendor-implementations/yealink/yealink.ts
+++ b/react-app/src/library/services/vendor-implementations/yealink/yealink.ts
@@ -82,7 +82,7 @@ export default class YealinkService extends VendorImplementation {
           const waiter = setTimeout(reject, 30000);
           this.requestWebHidPermissions(async () => {
             const productId = this.deductProductId(originalDeviceLabel);
-            const filters = [{ usage: HEADSET_USAGE, usagePage: HEADSET_USAGE_PAGE, vendorId: VENDOR_ID, productId }];
+            const filters = [{ usage: HEADSET_USAGE, usagePage: HEADSET_USAGE_PAGE, vendorId: VENDOR_ID, productId: productId || undefined }];
             await (window.navigator as any).hid.requestDevice({ filters });
             clearTimeout(waiter);
             const deviceLists: PartialHIDDevice[] = await (window.navigator as any).hid.getDevices();


### PR DESCRIPTION
Every HID consent request now will be consistent. 
When the label contains the product id, only the specific device will be available on the list.
When this is not the case, only devices of the specific vendor will be available.  