### PR TITLE
Feat: Use webhid sdk/package for Vbet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@gnaudio/jabra-js": "^4.2.1",
-        "@vbet/webhid-sdk": "^1.3.0",
+        "@vbet/webhid-sdk": "^1.4.0",
         "browserama": "^3.2.0",
         "fetch-jsonp": "^1.2.1",
         "rxjs": "^7.4.0",
@@ -3323,9 +3323,9 @@
       }
     },
     "node_modules/@vbet/webhid-sdk": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@vbet/webhid-sdk/-/webhid-sdk-1.3.0.tgz",
-      "integrity": "sha512-PkCZmMDfXGtyx22h0LWxMCo4CxnMfAjlzBgJoBdmWMi9gaTFvtZNhumybH676d8/WMasClQXHELzrV1QWyuOHg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@vbet/webhid-sdk/-/webhid-sdk-1.4.0.tgz",
+      "integrity": "sha512-zpQQLk+if5mF+Fztn4JHWcKSUl68iHPtUBsDXa4uXSl6ctytY6oK4c0kzM/qHGUn/9WLUj8oAxGoN0z3Gy/lew=="
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -16690,9 +16690,9 @@
       }
     },
     "@vbet/webhid-sdk": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@vbet/webhid-sdk/-/webhid-sdk-1.3.0.tgz",
-      "integrity": "sha512-PkCZmMDfXGtyx22h0LWxMCo4CxnMfAjlzBgJoBdmWMi9gaTFvtZNhumybH676d8/WMasClQXHELzrV1QWyuOHg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@vbet/webhid-sdk/-/webhid-sdk-1.4.0.tgz",
+      "integrity": "sha512-zpQQLk+if5mF+Fztn4JHWcKSUl68iHPtUBsDXa4uXSl6ctytY6oK4c0kzM/qHGUn/9WLUj8oAxGoN0z3Gy/lew=="
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@gnaudio/jabra-js": "^4.2.1",
+        "@vbet/webhid-sdk": "^1.1.0",
         "browserama": "^3.2.0",
         "fetch-jsonp": "^1.2.1",
         "rxjs": "^7.4.0",
@@ -3320,6 +3321,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@vbet/webhid-sdk": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vbet/webhid-sdk/-/webhid-sdk-1.1.0.tgz",
+      "integrity": "sha512-10dk5yZo19IKoCeOltgTJ2fUwc3dGuqCdIUa+vF8KYUmm0gmoI2P6dVpNPpTt/Xp4q7QBTcDcwiPGG5h84FelQ=="
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -16682,6 +16688,11 @@
         "@typescript-eslint/types": "4.33.0",
         "eslint-visitor-keys": "^2.0.0"
       }
+    },
+    "@vbet/webhid-sdk": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vbet/webhid-sdk/-/webhid-sdk-1.1.0.tgz",
+      "integrity": "sha512-10dk5yZo19IKoCeOltgTJ2fUwc3dGuqCdIUa+vF8KYUmm0gmoI2P6dVpNPpTt/Xp4q7QBTcDcwiPGG5h84FelQ=="
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@gnaudio/jabra-js": "^4.2.1",
-        "@vbet/webhid-sdk": "^1.2.0",
+        "@vbet/webhid-sdk": "^1.3.0",
         "browserama": "^3.2.0",
         "fetch-jsonp": "^1.2.1",
         "rxjs": "^7.4.0",
@@ -3323,9 +3323,9 @@
       }
     },
     "node_modules/@vbet/webhid-sdk": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@vbet/webhid-sdk/-/webhid-sdk-1.2.0.tgz",
-      "integrity": "sha512-9dPlq5ATGeazLWbrQ4n7RJv5jEJ1s8ulestMzmXCF0nn97XkNYT3fLc2IeBSD8K2vh4hFl1XwDKOKRa/8aP3/w=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@vbet/webhid-sdk/-/webhid-sdk-1.3.0.tgz",
+      "integrity": "sha512-PkCZmMDfXGtyx22h0LWxMCo4CxnMfAjlzBgJoBdmWMi9gaTFvtZNhumybH676d8/WMasClQXHELzrV1QWyuOHg=="
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -16690,9 +16690,9 @@
       }
     },
     "@vbet/webhid-sdk": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@vbet/webhid-sdk/-/webhid-sdk-1.2.0.tgz",
-      "integrity": "sha512-9dPlq5ATGeazLWbrQ4n7RJv5jEJ1s8ulestMzmXCF0nn97XkNYT3fLc2IeBSD8K2vh4hFl1XwDKOKRa/8aP3/w=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@vbet/webhid-sdk/-/webhid-sdk-1.3.0.tgz",
+      "integrity": "sha512-PkCZmMDfXGtyx22h0LWxMCo4CxnMfAjlzBgJoBdmWMi9gaTFvtZNhumybH676d8/WMasClQXHELzrV1QWyuOHg=="
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@gnaudio/jabra-js": "^4.2.1",
-        "@vbet/webhid-sdk": "^1.1.0",
+        "@vbet/webhid-sdk": "^1.2.0",
         "browserama": "^3.2.0",
         "fetch-jsonp": "^1.2.1",
         "rxjs": "^7.4.0",
@@ -3323,9 +3323,9 @@
       }
     },
     "node_modules/@vbet/webhid-sdk": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@vbet/webhid-sdk/-/webhid-sdk-1.1.0.tgz",
-      "integrity": "sha512-10dk5yZo19IKoCeOltgTJ2fUwc3dGuqCdIUa+vF8KYUmm0gmoI2P6dVpNPpTt/Xp4q7QBTcDcwiPGG5h84FelQ=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@vbet/webhid-sdk/-/webhid-sdk-1.2.0.tgz",
+      "integrity": "sha512-9dPlq5ATGeazLWbrQ4n7RJv5jEJ1s8ulestMzmXCF0nn97XkNYT3fLc2IeBSD8K2vh4hFl1XwDKOKRa/8aP3/w=="
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -16690,9 +16690,9 @@
       }
     },
     "@vbet/webhid-sdk": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@vbet/webhid-sdk/-/webhid-sdk-1.1.0.tgz",
-      "integrity": "sha512-10dk5yZo19IKoCeOltgTJ2fUwc3dGuqCdIUa+vF8KYUmm0gmoI2P6dVpNPpTt/Xp4q7QBTcDcwiPGG5h84FelQ=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@vbet/webhid-sdk/-/webhid-sdk-1.2.0.tgz",
+      "integrity": "sha512-9dPlq5ATGeazLWbrQ4n7RJv5jEJ1s8ulestMzmXCF0nn97XkNYT3fLc2IeBSD8K2vh4hFl1XwDKOKRa/8aP3/w=="
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@gnaudio/jabra-js": "^4.2.1",
-    "@vbet/webhid-sdk": "^1.3.0",
+    "@vbet/webhid-sdk": "^1.4.0",
     "browserama": "^3.2.0",
     "fetch-jsonp": "^1.2.1",
     "rxjs": "^7.4.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@gnaudio/jabra-js": "^4.2.1",
-    "@vbet/webhid-sdk": "^1.2.0",
+    "@vbet/webhid-sdk": "^1.3.0",
     "browserama": "^3.2.0",
     "fetch-jsonp": "^1.2.1",
     "rxjs": "^7.4.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@gnaudio/jabra-js": "^4.2.1",
+    "@vbet/webhid-sdk": "^1.1.0",
     "browserama": "^3.2.0",
     "fetch-jsonp": "^1.2.1",
     "rxjs": "^7.4.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@gnaudio/jabra-js": "^4.2.1",
-    "@vbet/webhid-sdk": "^1.1.0",
+    "@vbet/webhid-sdk": "^1.2.0",
     "browserama": "^3.2.0",
     "fetch-jsonp": "^1.2.1",
     "rxjs": "^7.4.0",

--- a/react-app/src/library/services/vendor-implementations/vbet/vbet.test.ts
+++ b/react-app/src/library/services/vendor-implementations/vbet/vbet.test.ts
@@ -1,6 +1,7 @@
+import { DeviceSignalType } from '@vbet/webhid-sdk';
 import VBetService from './vbet';
 
-const mockTestDevName = 'Test VBet Dev';
+const mockTestDevName = 'VT Lync (340b:0020)';
 const mockDeviceList0 = [];
 const mockDeviceList1 = [
   {
@@ -16,172 +17,749 @@ const mockDeviceList1 = [
       });
     }),
     productName: mockTestDevName,
-    productId: 0x0001,
+    productId: 13323,
     collections: [
       {
-        usage: 0x0005,
-        usagePage: 0x000b,
+        children: [],
+        featureReports: [],
         inputReports: [
           {
-            reportId: 0x08,
+            items: [
+              {
+                hasNull: false,
+                hasPreferredState: true,
+                isAbsolute: true,
+                isArray: false,
+                isBufferedBytes: false,
+                isConstant: false,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 0,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 1,
+                reportSize: 1,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [786665],
+                wrap: false,
+              },
+              {
+                hasNull: false,
+                hasPreferredState: true,
+                isAbsolute: true,
+                isArray: false,
+                isBufferedBytes: false,
+                isConstant: false,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 0,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 1,
+                reportSize: 1,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [786666],
+                wrap: false,
+              },
+              {
+                hasNull: false,
+                hasPreferredState: true,
+                isAbsolute: false,
+                isArray: false,
+                isBufferedBytes: false,
+                isConstant: false,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 0,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 6,
+                reportSize: 1,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [786432],
+                wrap: false,
+              },
+              {
+                hasNull: false,
+                hasPreferredState: true,
+                isAbsolute: true,
+                isArray: true,
+                isBufferedBytes: false,
+                isConstant: true,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 0,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 1,
+                reportSize: 112,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [],
+                wrap: false,
+              },
+            ],
+            reportId: 5,
           },
         ],
+        outputReports: [
+          {
+            items: [
+              {
+                hasNull: false,
+                hasPreferredState: true,
+                isAbsolute: true,
+                isArray: false,
+                isBufferedBytes: false,
+                isConstant: false,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: -1,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 15,
+                reportSize: 8,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [786432],
+                wrap: false,
+              },
+            ],
+            reportId: 5,
+          },
+        ],
+        type: 0,
+        usage: 1,
+        usagePage: 12,
       },
-    ],
-  },
-];
-
-const mockDeviceList2 = [
-  {
-    open: jest.fn(),
-    close: jest.fn(),
-    addEventListener: jest.fn((name, callback) => {
-      callback({
-        reportId: 0x01,
-        data: {
-          getUint8: jest.fn(),
-        },
-      });
-    }),
-    productName: mockTestDevName,
-    collections: [
       {
-        usage: 0,
-        usagePage: 0,
-      },
-    ],
-  },
-];
-
-const mockDeviceList3 = [
-  {
-    open: jest.fn(),
-    close: jest.fn(),
-    addEventListener: jest.fn((name, callback) => {
-      callback({
-        reportId: 0x01,
-        data: {
-          getUint8: jest.fn(),
-        },
-      });
-    }),
-    productName: mockTestDevName,
-    collections: [
-      {
-        usage: 0x0005,
-        usagePage: 0x000b,
-        inputReports: [],
-      },
-    ],
-  },
-];
-
-const mockDeviceList5 = [
-  {
-    open: jest.fn(),
-    close: jest.fn(),
-    sendReport: jest.fn(),
-    addEventListener: jest.fn((name, callback) => {
-      callback({
-        reportId: 0x01,
-        data: {
-          getUint8: jest.fn(),
-        },
-      });
-    }),
-    productName: mockTestDevName,
-    productId: 0x0020,
-    collections: [
-      {
-        usage: 0x0005,
-        usagePage: 0x000b,
+        children: [],
+        featureReports: [],
         inputReports: [
           {
-            reportId: 0x01,
+            items: [
+              {
+                hasNull: false,
+                hasPreferredState: true,
+                isAbsolute: true,
+                isArray: false,
+                isBufferedBytes: false,
+                isConstant: false,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 0,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 1,
+                reportSize: 1,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [720935],
+                wrap: false,
+              },
+              {
+                hasNull: false,
+                hasPreferredState: true,
+                isAbsolute: false,
+                isArray: false,
+                isBufferedBytes: false,
+                isConstant: false,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 0,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 1,
+                reportSize: 1,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [720931],
+                wrap: false,
+              },
+              {
+                hasNull: false,
+                hasPreferredState: true,
+                isAbsolute: true,
+                isArray: false,
+                isBufferedBytes: false,
+                isConstant: false,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 0,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 1,
+                reportSize: 1,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [720928],
+                wrap: false,
+              },
+              {
+                hasNull: false,
+                hasPreferredState: true,
+                isAbsolute: false,
+                isArray: false,
+                isBufferedBytes: false,
+                isConstant: false,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 0,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 1,
+                reportSize: 1,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [720943],
+                wrap: false,
+              },
+              {
+                hasNull: false,
+                hasPreferredState: true,
+                isAbsolute: true,
+                isArray: false,
+                isBufferedBytes: false,
+                isConstant: false,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 0,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 1,
+                reportSize: 1,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [721047],
+                wrap: false,
+              },
+              {
+                hasNull: false,
+                hasPreferredState: true,
+                isAbsolute: true,
+                isArray: false,
+                isBufferedBytes: false,
+                isConstant: false,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 0,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 1,
+                reportSize: 1,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [589831],
+                wrap: false,
+              },
+              {
+                hasNull: false,
+                hasPreferredState: true,
+                isAbsolute: true,
+                isArray: false,
+                isBufferedBytes: false,
+                isConstant: false,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 0,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 1,
+                reportSize: 1,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [720929],
+                wrap: false,
+              },
+              {
+                hasNull: false,
+                hasPreferredState: true,
+                isAbsolute: true,
+                isArray: false,
+                isBufferedBytes: false,
+                isConstant: false,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 0,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 1,
+                reportSize: 1,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [720896],
+                wrap: false,
+              },
+              {
+                hasNull: false,
+                hasPreferredState: true,
+                isAbsolute: false,
+                isArray: false,
+                isBufferedBytes: false,
+                isConstant: false,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 1,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 14,
+                reportSize: 8,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [720896],
+                wrap: false,
+              },
+            ],
+            reportId: 1,
           },
         ],
-      },
-    ],
-  },
-];
-
-const mockDeviceList6 = [
-  {
-    open: jest.fn(),
-    close: jest.fn(),
-    sendReport: jest.fn(),
-    addEventListener: jest.fn((name, callback) => {
-      callback({
-        reportId: 0x01,
-        data: {
-          getUint8: jest.fn(),
-        },
-      });
-    }),
-    productName: mockTestDevName,
-    productId: 0x0014,
-    collections: [
-      {
-        usage: 0x0005,
-        usagePage: 0x000b,
-        inputReports: [
+        outputReports: [
           {
-            reportId: 0x01,
+            items: [
+              {
+                hasNull: false,
+                hasPreferredState: true,
+                isAbsolute: true,
+                isArray: false,
+                isBufferedBytes: false,
+                isConstant: false,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 1,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 15,
+                reportSize: 8,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [134152192],
+                wrap: false,
+              },
+            ],
+            reportId: 1,
           },
-        ],
-      },
-    ],
-  },
-];
-
-const mockDeviceList7 = [
-  {
-    open: jest.fn(),
-    close: jest.fn(),
-    sendReport: jest.fn(),
-    addEventListener: jest.fn((name, callback) => {
-      callback({
-        reportId: 0x05,
-        data: {
-          getUint8: jest.fn(),
-        },
-      });
-    }),
-    productName: mockTestDevName,
-    productId: 0x0040,
-    collections: [
-      {
-        usage: 0x0005,
-        usagePage: 0x000b,
-        inputReports: [
           {
-            reportId: 0x05,
+            items: [
+              {
+                hasNull: false,
+                hasPreferredState: false,
+                isAbsolute: true,
+                isArray: false,
+                isBufferedBytes: false,
+                isConstant: false,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 0,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 1,
+                reportSize: 1,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [524311],
+                wrap: false,
+              },
+              {
+                hasNull: false,
+                hasPreferredState: false,
+                isAbsolute: true,
+                isArray: false,
+                isBufferedBytes: false,
+                isConstant: false,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 0,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 1,
+                reportSize: 1,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [524320],
+                wrap: false,
+              },
+              {
+                hasNull: false,
+                hasPreferredState: false,
+                isAbsolute: true,
+                isArray: false,
+                isBufferedBytes: false,
+                isConstant: false,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 0,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 1,
+                reportSize: 1,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [524321],
+                wrap: false,
+              },
+              {
+                hasNull: false,
+                hasPreferredState: true,
+                isAbsolute: true,
+                isArray: true,
+                isBufferedBytes: false,
+                isConstant: true,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 0,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 1,
+                reportSize: 117,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [],
+                wrap: false,
+              },
+            ],
+            reportId: 2,
+          },
+          {
+            items: [
+              {
+                hasNull: false,
+                hasPreferredState: true,
+                isAbsolute: true,
+                isArray: false,
+                isBufferedBytes: false,
+                isConstant: false,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 0,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 1,
+                reportSize: 1,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [524297],
+                wrap: false,
+              },
+              {
+                hasNull: false,
+                hasPreferredState: true,
+                isAbsolute: true,
+                isArray: true,
+                isBufferedBytes: false,
+                isConstant: true,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 0,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 1,
+                reportSize: 119,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [],
+                wrap: false,
+              },
+            ],
+            reportId: 3,
+          },
+          {
+            items: [
+              {
+                hasNull: false,
+                hasPreferredState: true,
+                isAbsolute: true,
+                isArray: false,
+                isBufferedBytes: false,
+                isConstant: false,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 0,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 1,
+                reportSize: 1,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [524312],
+                wrap: false,
+              },
+              {
+                hasNull: false,
+                hasPreferredState: true,
+                isAbsolute: true,
+                isArray: true,
+                isBufferedBytes: false,
+                isConstant: true,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 0,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 1,
+                reportSize: 119,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [],
+                wrap: false,
+              },
+            ],
+            reportId: 4,
+          },
+          {
+            items: [
+              {
+                hasNull: false,
+                hasPreferredState: true,
+                isAbsolute: true,
+                isArray: false,
+                isBufferedBytes: false,
+                isConstant: false,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 0,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 1,
+                reportSize: 1,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [524358],
+                wrap: false,
+              },
+              {
+                hasNull: false,
+                hasPreferredState: true,
+                isAbsolute: true,
+                isArray: true,
+                isBufferedBytes: false,
+                isConstant: true,
+                isLinear: true,
+                isRange: false,
+                isVolatile: false,
+                logicalMaximum: 0,
+                logicalMinimum: 0,
+                physicalMaximum: 0,
+                physicalMinimum: 0,
+                reportCount: 1,
+                reportSize: 119,
+                unitExponent: 0,
+                unitFactorCurrentExponent: 0,
+                unitFactorLengthExponent: 0,
+                unitFactorLuminousIntensityExponent: 0,
+                unitFactorMassExponent: 0,
+                unitFactorTemperatureExponent: 0,
+                unitFactorTimeExponent: 0,
+                unitSystem: 'none',
+                usages: [],
+                wrap: false,
+              },
+            ],
+            reportId: 6,
           },
         ],
+        type: 0,
+        usage: 5,
+        usagePage: 11,
       },
     ],
   },
+  {}
 ];
-
-const mockOffhookFlag = {
-  BT100USeries: 0x04,
-  CMEDIASeries: 0x01,
-  DECTSeries: 0x02,
-  ACTIONSeries: 0x20,
-};
-const mockOnhookFlag = {
-  BT100USeries: 0x00,
-  CMEDIASeries: 0x00,
-  DECTSeries: 0x00,
-  ACTIONSeries: 0x00,
-};
-const mockMuteFlag = {
-  BT100USeries: 0x0c,
-  CMEDIASeries: 0x14,
-  DECTSeries: [0x03, 0x04],
-  ACTIONSeries: [0x05, 0x01],
-};
-const mockReject = { BT100USeries: 0x10, ACTIONSeries: 0x08 };
 
 describe('VBetservice', () => {
   let vbetService: VBetService;
@@ -194,7 +772,7 @@ describe('VBetservice', () => {
         return mockDeviceList;
       },
       requestDevice: () => {
-        mockDeviceList = mockReqDeviceList;
+        return mockReqDeviceList;
       },
     }),
   });
@@ -251,56 +829,6 @@ describe('VBetservice', () => {
       vbetService.disconnect();
     });
 
-    it('should connect with previouslyConnectedDevice', async () => {
-      const statusChangeSpy = jest.spyOn(vbetService, 'changeConnectionStatus');
-      mockDeviceList = mockDeviceList1;
-      await vbetService.connect(mockTestDevName);
-      const devName = vbetService.deviceInfo;
-      expect(devName.ProductName).toBe(mockTestDevName);
-      expect(statusChangeSpy).toHaveBeenCalledWith({ isConnected: true, isConnecting: false });
-    });
-
-    it('already have active device', async () => {
-      const statusChangeSpy = jest.spyOn(vbetService, 'changeConnectionStatus');
-      mockDeviceList = mockDeviceList1;
-      await vbetService.connect(mockTestDevName);
-      await vbetService.connect(mockTestDevName);
-      expect(statusChangeSpy).toHaveBeenCalledWith({ isConnected: true, isConnecting: false });
-    });
-
-    it('device usage not match', async () => {
-      const statusChangeSpy = jest.spyOn(vbetService, 'changeConnectionStatus');
-      vbetService.requestWebHidPermissions = jest.fn((callback) => {
-        mockReqDeviceList = mockDeviceList0;
-        callback();
-      });
-      mockDeviceList = mockDeviceList2;
-      await vbetService.connect(mockTestDevName);
-      expect(statusChangeSpy).toHaveBeenCalledWith({ isConnected: false, isConnecting: false });
-    });
-
-    it('device inputReports is empty', async () => {
-      vbetService.requestWebHidPermissions = jest.fn((callback) => {
-        mockReqDeviceList = mockDeviceList0;
-        callback();
-      });
-      mockDeviceList = mockDeviceList3;
-      await vbetService.connect(mockTestDevName);
-      expect(vbetService.isConnected).toBe(true);
-      expect(vbetService.isConnecting).toBe(false);
-    });
-
-    it('previouslyConnectedDevice not have device', async () => {
-      const statusChangeSpy = jest.spyOn(vbetService, 'changeConnectionStatus');
-      vbetService.requestWebHidPermissions = jest.fn((callback) => {
-        mockReqDeviceList = mockDeviceList0;
-        callback();
-      });
-      mockDeviceList = mockDeviceList1;
-      await vbetService.connect('test');
-      expect(statusChangeSpy).toHaveBeenCalledWith({ isConnected: false, isConnecting: false });
-    });
-
     it('webhidRequest, 30s timeout, failed to connect', async () => {
       const statusChangeSpy = jest.spyOn(vbetService, 'changeConnectionStatus');
       jest.useFakeTimers();
@@ -315,7 +843,46 @@ describe('VBetservice', () => {
       jest.useRealTimers();
     });
 
-    it('webhidRequest, connect success', async () => {
+    it('webhidRequest, connect with previously connected device', async () => {
+      const statusChangeSpy = jest.spyOn(vbetService, 'changeConnectionStatus');
+      const requestSpy = (vbetService.requestWebHidPermissions = jest.fn());
+      mockDeviceList = mockDeviceList1;
+      await vbetService.connect(mockTestDevName);
+
+      const devName = vbetService.deviceInfo;
+      expect(devName.ProductName).toBe(mockTestDevName);
+      expect(requestSpy).not.toHaveBeenCalled();
+      expect(statusChangeSpy).toHaveBeenCalledWith({ isConnected: true, isConnecting: false });
+    });
+
+    it('webhidRequest, connect with previously connected device but label not matched', async () => {
+      const statusChangeSpy = jest.spyOn(vbetService, 'changeConnectionStatus');
+      const requestSpy = (vbetService.requestWebHidPermissions = jest.fn((callback) => {
+        mockReqDeviceList = mockDeviceList1;
+        callback();
+      }));
+      mockDeviceList = mockDeviceList1;
+      await vbetService.connect('random name');
+
+      const devName = vbetService.deviceInfo;
+      expect(devName.ProductName).toBe(mockTestDevName);
+      expect(requestSpy).toHaveBeenCalled();
+      expect(statusChangeSpy).toHaveBeenCalledWith({ isConnected: true, isConnecting: false });
+    });
+
+    it('webhidRequest, let users select from dev list if label not matched', async () => {
+      const statusChangeSpy = jest.spyOn(vbetService, 'changeConnectionStatus');
+      const requestSpy = (vbetService.requestWebHidPermissions = jest.fn((callback) => {
+        mockReqDeviceList = mockDeviceList1;
+        callback();
+      }));
+
+      await vbetService.connect('random name');
+      expect(requestSpy).toHaveBeenCalled();
+      expect(statusChangeSpy).toHaveBeenCalledWith({ isConnected: true, isConnecting: false });
+    });
+
+    it('webhidRequest, let users select from dev list if label matched', async () => {
       const statusChangeSpy = jest.spyOn(vbetService, 'changeConnectionStatus');
       const requestSpy = (vbetService.requestWebHidPermissions = jest.fn((callback) => {
         mockReqDeviceList = mockDeviceList1;
@@ -329,48 +896,11 @@ describe('VBetservice', () => {
 
     it('webhidRequest, connect fail', async () => {
       const statusChangeSpy = jest.spyOn(vbetService, 'changeConnectionStatus');
-      const requestSpy = (vbetService.requestWebHidPermissions = jest.fn((callback) => {
-        callback();
-      }));
+      const requestSpy = (vbetService.requestWebHidPermissions = jest.fn((callback) => callback()));
 
       await vbetService.connect(mockTestDevName);
       expect(requestSpy).toHaveBeenCalled();
       expect(statusChangeSpy).toHaveBeenCalledWith({ isConnected: false, isConnecting: false });
-    });
-
-    it('webhidRequest, connect fail, device name error', async () => {
-      const statusChangeSpy = jest.spyOn(vbetService, 'changeConnectionStatus');
-      const requestSpy = (vbetService.requestWebHidPermissions = jest.fn((callback) => {
-        mockReqDeviceList = mockDeviceList1;
-        callback();
-      }));
-
-      await vbetService.connect('test');
-      expect(requestSpy).toHaveBeenCalled();
-      expect(statusChangeSpy).toHaveBeenCalledWith({ isConnected: false, isConnecting: false });
-    });
-
-    it('webhidRequest, connect fail, device usage error', async () => {
-      const statusChangeSpy = jest.spyOn(vbetService, 'changeConnectionStatus');
-      const requestSpy = (vbetService.requestWebHidPermissions = jest.fn((callback) => {
-        mockReqDeviceList = mockDeviceList2;
-        callback();
-      }));
-
-      await vbetService.connect(mockTestDevName);
-      expect(requestSpy).toHaveBeenCalled();
-      expect(statusChangeSpy).toHaveBeenCalledWith({ isConnected: false, isConnecting: false });
-    });
-
-    it('webhidRequest, device inputReports is empty', async () => {
-      vbetService.requestWebHidPermissions = jest.fn((callback) => {
-        mockReqDeviceList = mockDeviceList3;
-        callback();
-      });
-
-      await vbetService.connect(mockTestDevName);
-      expect(vbetService.isConnected).toBe(true);
-      expect(vbetService.isConnecting).toBe(false);
     });
   });
 
@@ -385,7 +915,7 @@ describe('VBetservice', () => {
     });
   });
 
-  describe('processBtnPress BT100USeries', () => {
+  describe('telephoney control', () => {
     beforeEach(async () => {
       mockDeviceList = mockDeviceList1;
       await vbetService.connect(mockTestDevName);
@@ -396,216 +926,52 @@ describe('VBetservice', () => {
       await vbetService.disconnect();
     });
 
-    it('activeDevice is null', async () => {
-      const ansFun = jest.spyOn(vbetService, 'answerCall');
-      await vbetService.disconnect();
-      await vbetService.processBtnPress(mockOffhookFlag.BT100USeries);
-      expect(ansFun).not.toHaveBeenCalled();
-    });
-
-    it('test offhook', async () => {
+    it('accept inbound call', async () => {
       const ansFun = jest.spyOn(vbetService, 'answerCall');
       const devAnsFun = jest.spyOn(vbetService, 'deviceAnsweredCall');
+
       await vbetService.incomingCall({ conversationId: 'id' });
-      await vbetService.processBtnPress(mockOffhookFlag.BT100USeries);
+      vbetService.processBtnPress(DeviceSignalType.ACCEPT_CALL);
       expect(ansFun).toHaveBeenCalled();
       expect(devAnsFun).toHaveBeenCalled();
     });
 
-    it('test offhook but no active conversion id', async () => {
-      const ansFun = jest.spyOn(vbetService, 'sendOpToDevice');
-      const devAnsFun = jest.spyOn(vbetService, 'deviceAnsweredCall');
-      await vbetService.processBtnPress(mockOffhookFlag.BT100USeries);
-      expect(ansFun).not.toHaveBeenCalledWith('offHook');
-      expect(devAnsFun).not.toHaveBeenCalled();
-    });
+    it('reject inbound call', async () => {
+      const rejFun = jest.spyOn(vbetService, 'rejectCall');
+      const devRejFun = jest.spyOn(vbetService, 'deviceRejectedCall');
 
-    it('test onhook', async () => {
-      const ansFun = jest.spyOn(vbetService, 'endCallFromDevice');
-      const devAnsFun = jest.spyOn(vbetService, 'deviceEndedCall');
       await vbetService.incomingCall({ conversationId: 'id' });
-      await vbetService.processBtnPress(mockOffhookFlag.BT100USeries);
-      await vbetService.processBtnPress(mockOnhookFlag.BT100USeries);
-      expect(ansFun).toHaveBeenCalled();
-      expect(devAnsFun).toHaveBeenCalled();
+      vbetService.processBtnPress(DeviceSignalType.REJECT_CALL);
+      expect(rejFun).toHaveBeenCalled();
+      expect(devRejFun).toHaveBeenCalled();
     });
 
-    it('test onhook but no active conversion id', async () => {
-      const ansFun = jest.spyOn(vbetService, 'sendOpToDevice');
-      const devAnsFun = jest.spyOn(vbetService, 'deviceEndedCall');
-      await vbetService.incomingCall({ conversationId: 'id' });
-      await vbetService.processBtnPress(mockOffhookFlag.BT100USeries);
-      vbetService.activeConversationId = null;
-      await vbetService.processBtnPress(mockOnhookFlag.BT100USeries);
-      expect(ansFun).not.toHaveBeenCalledWith('onHook');
-      expect(devAnsFun).not.toHaveBeenCalled();
+    it('end current call', async () => {
+      const endFun = jest.spyOn(vbetService, 'endCall');
+      const devEndFun = jest.spyOn(vbetService, 'deviceEndedCall');
+
+      await vbetService.outgoingCall({ conversationId: 'id' });
+      vbetService.processBtnPress(DeviceSignalType.END_CALL);
+      expect(endFun).toHaveBeenCalled();
+      expect(devEndFun).toHaveBeenCalled();
     });
 
-    it('test mute', async () => {
-      const setMuteFun = jest.spyOn(vbetService, 'setMute');
+    it('mute/unmute current call', async () => {
+      const muteFun = jest.spyOn(vbetService, 'setMute');
       const devMuteFun = jest.spyOn(vbetService, 'deviceMuteChanged');
-      await vbetService.incomingCall({ conversationId: 'id' });
-      await vbetService.processBtnPress(mockOffhookFlag.BT100USeries);
-      await vbetService.processBtnPress(mockMuteFlag.BT100USeries);
-      expect(setMuteFun).toHaveBeenCalledWith(true);
-      expect(devMuteFun).toHaveBeenCalledWith({
-        isMuted: true,
-        name: 'CallMuted',
-        conversationId: 'id',
-      });
-    });
 
-    it('test unmute', async () => {
-      const setMuteFun = jest.spyOn(vbetService, 'setMute');
-      const devMuteFun = jest.spyOn(vbetService, 'deviceMuteChanged');
-      await vbetService.incomingCall({ conversationId: 'id' });
-      await vbetService.processBtnPress(mockOffhookFlag.BT100USeries);
-      await vbetService.processBtnPress(mockMuteFlag.BT100USeries);
-      await vbetService.processBtnPress(mockMuteFlag.BT100USeries);
-      expect(setMuteFun).toHaveBeenCalledTimes(2);
+      await vbetService.outgoingCall({ conversationId: 'id' });
+      vbetService.processBtnPress(DeviceSignalType.MUTE_CALL);
+      vbetService.processBtnPress(DeviceSignalType.UNMUTE_CALL);
+      expect(muteFun).toHaveBeenCalledTimes(2);
       expect(devMuteFun).toHaveBeenCalledTimes(2);
-    });
-
-    it('test rejectCall', async () => {
-      const devRejectFun = jest.spyOn(vbetService, 'deviceRejectedCall');
-      const setRejectFun = jest.spyOn(vbetService, 'rejectCall');
-      await vbetService.incomingCall({ conversationId: 'id' });
-      await vbetService.processBtnPress(mockReject.BT100USeries);
-      expect(devRejectFun).toHaveBeenCalledWith({ name: 'Reject', conversationId: 'id' });
-      expect(setRejectFun).toHaveBeenCalled();
-    });
-
-    it('test outgoing call', async () => {
-      const ansFun = jest.spyOn(vbetService, 'endCallFromDevice');
-      const devAnsFun = jest.spyOn(vbetService, 'deviceEndedCall');
-      await vbetService.outgoingCall({ conversationId: 'id' });
-      await vbetService.processBtnPress(mockOnhookFlag.BT100USeries);
-      expect(ansFun).toHaveBeenCalled();
-      expect(devAnsFun).toHaveBeenCalled();
-    });
-
-    it('test auto answer call', async () => {
-      const ansFun = jest.spyOn(vbetService, 'sendOpToDevice');
-      await vbetService.answerCall('id', true);
-      expect(ansFun).toHaveBeenCalledWith('ring');
-      expect(ansFun).toHaveBeenCalledWith('offHook');
-    });
-  });
-
-  describe('processBtnPress CMEDIASeries', () => {
-    beforeEach(async () => {
-      mockDeviceList = mockDeviceList5;
-      await vbetService.connect(mockTestDevName);
-    });
-
-    afterEach(async () => {
-      await vbetService.endAllCalls();
-      await vbetService.disconnect();
-    });
-
-    it('activeDevice is null', async () => {
-      await vbetService.disconnect();
-      const ansFun = jest.spyOn(vbetService, 'answerCall');
-      await vbetService.processBtnPress(mockOffhookFlag.CMEDIASeries);
-      expect(ansFun).not.toHaveBeenCalled();
-    });
-
-    it('test offhook', async () => {
-      const ansFun = jest.spyOn(vbetService, 'answerCall');
-      const devAnsFun = jest.spyOn(vbetService, 'deviceAnsweredCall');
-      await vbetService.incomingCall({ conversationId: 'id' });
-      await vbetService.processBtnPress(mockOffhookFlag.CMEDIASeries);
-      expect(ansFun).toHaveBeenCalled();
-      expect(devAnsFun).toHaveBeenCalled();
-    });
-
-    it('test mute', async () => {
-      const setMuteFun = jest.spyOn(vbetService, 'setMute');
-      const devMuteFun = jest.spyOn(vbetService, 'deviceMuteChanged');
-      await vbetService.incomingCall({ conversationId: 'id' });
-      await vbetService.processBtnPress(mockOffhookFlag.CMEDIASeries);
-      await vbetService.processBtnPress(mockMuteFlag.CMEDIASeries);
-      expect(setMuteFun).toHaveBeenCalledWith(true);
+      expect(muteFun).toHaveBeenCalledWith(true);
       expect(devMuteFun).toHaveBeenCalledWith({
         isMuted: true,
         name: 'CallMuted',
         conversationId: 'id',
       });
-    });
-
-    it('test mute', async () => {
-      const setMuteFun = jest.spyOn(vbetService, 'setMute');
-      const devMuteFun = jest.spyOn(vbetService, 'deviceMuteChanged');
-      await vbetService.incomingCall({ conversationId: 'id' });
-      await vbetService.processBtnPress(mockOffhookFlag.CMEDIASeries);
-      await vbetService.processBtnPress(0x08);
-      await vbetService.processBtnPress(0x00);
-      expect(setMuteFun).toHaveBeenCalledWith(true);
-      expect(devMuteFun).toHaveBeenCalledWith({
-        isMuted: true,
-        name: 'CallMuted',
-        conversationId: 'id',
-      });
-    });
-
-    it('test outgoing call', async () => {
-      const ansFun = jest.spyOn(vbetService, 'endCallFromDevice');
-      const devAnsFun = jest.spyOn(vbetService, 'deviceEndedCall');
-      await vbetService.outgoingCall({ conversationId: 'id' });
-      await vbetService.processBtnPress(mockOnhookFlag.CMEDIASeries);
-      expect(ansFun).toHaveBeenCalled();
-      expect(devAnsFun).toHaveBeenCalled();
-    });
-  });
-
-  describe('processBtnPress DECTSeries', () => {
-    beforeEach(async () => {
-      mockDeviceList = mockDeviceList6;
-      await vbetService.connect(mockTestDevName);
-    });
-
-    afterEach(async () => {
-      await vbetService.endAllCalls();
-      await vbetService.disconnect();
-    });
-
-    it('activeDevice is null', async () => {
-      await vbetService.disconnect();
-      const ansFun = jest.spyOn(vbetService, 'answerCall');
-      await vbetService.processBtnPress(mockOffhookFlag.DECTSeries);
-      expect(ansFun).not.toHaveBeenCalled();
-    });
-
-    it('test offhook', async () => {
-      const ansFun = jest.spyOn(vbetService, 'answerCall');
-      const devAnsFun = jest.spyOn(vbetService, 'deviceAnsweredCall');
-      await vbetService.incomingCall({ conversationId: 'id' });
-      await vbetService.processBtnPress(mockOffhookFlag.DECTSeries);
-      expect(ansFun).toHaveBeenCalled();
-      expect(devAnsFun).toHaveBeenCalled();
-    });
-
-    it('test mute', async () => {
-      const setMuteFun = jest.spyOn(vbetService, 'setMute');
-      const devMuteFun = jest.spyOn(vbetService, 'deviceMuteChanged');
-      await vbetService.incomingCall({ conversationId: 'id' });
-      await vbetService.processBtnPress(mockOffhookFlag.DECTSeries);
-      await vbetService.processBtnPress(mockMuteFlag.DECTSeries[0]);
-      expect(setMuteFun).toHaveBeenCalledWith(true);
-      expect(devMuteFun).toHaveBeenCalledWith({
-        isMuted: true,
-        name: 'CallMuted',
-        conversationId: 'id',
-      });
-    });
-
-    it('test unmute', async () => {
-      const setMuteFun = jest.spyOn(vbetService, 'setMute');
-      const devMuteFun = jest.spyOn(vbetService, 'deviceMuteChanged');
-      await vbetService.incomingCall({ conversationId: 'id' });
-      await vbetService.processBtnPress(mockOffhookFlag.DECTSeries);
-      await vbetService.processBtnPress(mockMuteFlag.DECTSeries[1]);
-      expect(setMuteFun).toHaveBeenCalledWith(false);
+      expect(muteFun).toHaveBeenCalledWith(false);
       expect(devMuteFun).toHaveBeenCalledWith({
         isMuted: false,
         name: 'CallUnmuted',
@@ -613,129 +979,81 @@ describe('VBetservice', () => {
       });
     });
 
-    it('test outgoing call', async () => {
-      const ansFun = jest.spyOn(vbetService, 'endCallFromDevice');
-      const devAnsFun = jest.spyOn(vbetService, 'deviceEndedCall');
-      await vbetService.outgoingCall({ conversationId: 'id' });
-      await vbetService.processBtnPress(mockOnhookFlag.DECTSeries);
-      expect(ansFun).toHaveBeenCalled();
-      expect(devAnsFun).toHaveBeenCalled();
-    });
-  });
-
-  describe('processBtnPress ACTIONSeries', () => {
-    beforeEach(async () => {
-      mockDeviceList = mockDeviceList7;
-      await vbetService.connect(mockTestDevName);
-    });
-
-    afterEach(async () => {
-      await vbetService.endAllCalls();
-      await vbetService.disconnect();
-    });
-
-    it('activeDevice is null', async () => {
-      await vbetService.disconnect();
-      const ansFun = jest.spyOn(vbetService, 'answerCall');
-      await vbetService.processBtnPress(mockOffhookFlag.ACTIONSeries);
-      expect(ansFun).not.toHaveBeenCalled();
-    });
-
-    it('test offhook', async () => {
+    it('answer inbound call but no id', async () => {
       const ansFun = jest.spyOn(vbetService, 'answerCall');
       const devAnsFun = jest.spyOn(vbetService, 'deviceAnsweredCall');
-      await vbetService.incomingCall({ conversationId: 'id' });
-      await vbetService.processBtnPress(mockOffhookFlag.ACTIONSeries);
-      expect(ansFun).toHaveBeenCalled();
-      expect(devAnsFun).toHaveBeenCalled();
-    });
 
-    it('test reject', async () => {
-      const ansFun = jest.spyOn(vbetService, 'rejectCall');
-      const devAnsFun = jest.spyOn(vbetService, 'deviceRejectedCall');
-      await vbetService.incomingCall({ conversationId: 'id' });
-      await vbetService.processBtnPress(mockReject.ACTIONSeries);
-      expect(ansFun).toHaveBeenCalled();
-      expect(devAnsFun).toHaveBeenCalled();
-    });
-
-    it('test mute', async () => {
-      const setMuteFun = jest.spyOn(vbetService, 'setMute');
-      const devMuteFun = jest.spyOn(vbetService, 'deviceMuteChanged');
-      await vbetService.incomingCall({ conversationId: 'id' });
-      await vbetService.processBtnPress(mockOffhookFlag.ACTIONSeries);
-      await vbetService.processBtnPress(mockMuteFlag.ACTIONSeries[0]);
-      expect(setMuteFun).toHaveBeenCalledWith(true);
-      expect(devMuteFun).toHaveBeenCalledWith({
-        isMuted: true,
-        name: 'CallMuted',
-        conversationId: 'id',
-      });
-    });
-
-    it('test unmute', async () => {
-      const setMuteFun = jest.spyOn(vbetService, 'setMute');
-      const devMuteFun = jest.spyOn(vbetService, 'deviceMuteChanged');
-      await vbetService.incomingCall({ conversationId: 'id' });
-      await vbetService.processBtnPress(mockOffhookFlag.ACTIONSeries);
-      await vbetService.processBtnPress(mockMuteFlag.ACTIONSeries[1]);
-      expect(setMuteFun).toHaveBeenCalledWith(false);
-      expect(devMuteFun).toHaveBeenCalledWith({
-        isMuted: false,
-        name: 'CallUnmuted',
-        conversationId: 'id',
-      });
-    });
-
-    it('test outgoing call', async () => {
-      const ansFun = jest.spyOn(vbetService, 'endCallFromDevice');
-      const devAnsFun = jest.spyOn(vbetService, 'deviceEndedCall');
-      await vbetService.outgoingCall({ conversationId: 'id' });
-      await vbetService.processBtnPress(mockOnhookFlag.ACTIONSeries);
-      expect(ansFun).toHaveBeenCalled();
-      expect(devAnsFun).toHaveBeenCalled();
-    });
-  });
-
-  describe('endcall from user interface', () => {
-    beforeEach(async () => {
-      mockDeviceList = mockDeviceList1;
-      await vbetService.connect(mockTestDevName);
-    });
-
-    afterEach(async () => {
-      await vbetService.disconnect();
-    });
-
-    it('test onhook', async () => {
-      const ansFun = jest.spyOn(vbetService, 'sendOpToDevice');
-      await vbetService.incomingCall({ conversationId: 'id' });
-      await vbetService.processBtnPress(mockOffhookFlag.BT100USeries);
-      await vbetService.endCall('id', false);
-      expect(ansFun).toHaveBeenCalledWith('onHook');
-    });
-
-    it('test onhook with other active calls', async () => {
-      const ansFun = jest.spyOn(vbetService, 'sendOpToDevice');
-      await vbetService.incomingCall({ conversationId: 'id' });
-      await vbetService.processBtnPress(mockOffhookFlag.BT100USeries);
-      await vbetService.endCall('id', true);
-      expect(ansFun).not.toHaveBeenCalledWith('onHook');
-    });
-
-    it('test onhook but no matching conversion id', async () => {
-      const ansFun = jest.spyOn(vbetService, 'sendOpToDevice');
-      await vbetService.incomingCall({ conversationId: 'id' });
-      await vbetService.processBtnPress(mockOffhookFlag.BT100USeries);
-      await vbetService.endCall('dif', false);
-      expect(ansFun).not.toHaveBeenCalledWith('onHook');
-    });
-
-    it('test reject call but no pending conversion id', async () => {
-      const ansFun = jest.spyOn(vbetService, 'sendOpToDevice');
       await vbetService.incomingCall({ conversationId: '' });
-      await vbetService.rejectCall();
-      expect(ansFun).not.toHaveBeenCalledWith('onHook');
+      vbetService.processBtnPress(DeviceSignalType.ACCEPT_CALL);
+      expect(ansFun).not.toHaveBeenCalled();
+      expect(devAnsFun).not.toHaveBeenCalled();
+    });
+
+    it('end call but no id', async () => {
+      const endFun = jest.spyOn(vbetService, 'endCall');
+      const devEndFun = jest.spyOn(vbetService, 'deviceEndedCall');
+
+      await vbetService.outgoingCall({ conversationId: 'id' });
+      await vbetService.endCall('id');
+      vbetService.processBtnPress(DeviceSignalType.END_CALL);
+      expect(endFun).toHaveBeenCalledTimes(1);
+      expect(devEndFun).not.toHaveBeenCalled();
+    });
+
+    it('mute call but no id', async () => {
+      const muteFun = jest.spyOn(vbetService, 'setMute');
+      const devMuteFun = jest.spyOn(vbetService, 'deviceMuteChanged');
+
+      await vbetService.outgoingCall({ conversationId: 'id' });
+      vbetService.processBtnPress(DeviceSignalType.MUTE_CALL);
+      await vbetService.endCall('id');
+      vbetService.processBtnPress(DeviceSignalType.MUTE_CALL);
+      expect(muteFun).toHaveBeenCalledTimes(1);
+      expect(devMuteFun).toHaveBeenCalledTimes(1);
+    });
+
+    it('reject call but no id', async () => {
+      const rejectFun = jest.spyOn(vbetService, 'rejectCall');
+      const devRejectFun = jest.spyOn(vbetService, 'deviceRejectedCall');
+
+      await vbetService.incomingCall({ conversationId: 'id' });
+      await vbetService.endAllCalls();
+      vbetService.processBtnPress(DeviceSignalType.REJECT_CALL);
+      expect(rejectFun).not.toHaveBeenCalled();
+      expect(devRejectFun).not.toHaveBeenCalled();
+    });
+
+    it('answer inbound call from ui but no id', async () => {
+      const ansFun = jest.spyOn(vbetService, 'answerCall');
+      const devAnsFun = jest.spyOn(vbetService, 'deviceAnsweredCall');
+
+      await vbetService.incomingCall({ conversationId: 'id' });
+      vbetService.processBtnPress(DeviceSignalType.ACCEPT_CALL);
+      vbetService.answerCall('id');
+      expect(ansFun).toHaveBeenCalled();
+      expect(devAnsFun).toHaveBeenCalled();
+    });
+
+    it('reject call from ui but no id', async () => {
+      const rejectFun = jest.spyOn(vbetService, 'rejectCall');
+      const devRejectFun = jest.spyOn(vbetService, 'deviceRejectedCall');
+
+      await vbetService.incomingCall({ conversationId: 'id' });
+      vbetService.processBtnPress(DeviceSignalType.REJECT_CALL);
+      vbetService.rejectCall('id');
+      expect(rejectFun).toHaveBeenCalled();
+      expect(devRejectFun).toHaveBeenCalled();
+    });
+
+    it('end call from ui but no id', async () => {
+      const endFun = jest.spyOn(vbetService, 'endCall');
+      const devEndFun = jest.spyOn(vbetService, 'deviceEndedCall');
+
+      await vbetService.outgoingCall({ conversationId: 'id' });
+      vbetService.processBtnPress(DeviceSignalType.END_CALL);
+      vbetService.endCall('id');
+      expect(endFun).toHaveBeenCalled();
+      expect(devEndFun).toHaveBeenCalled();
     });
   });
 });

--- a/react-app/src/library/services/vendor-implementations/vbet/vbet.ts
+++ b/react-app/src/library/services/vendor-implementations/vbet/vbet.ts
@@ -1,27 +1,17 @@
 import { VendorImplementation, ImplementationConfig } from '../vendor-implementation';
 import { CallInfo } from '../../..';
-import DeviceInfo from '../../../types/device-info';
-import { PartialInputReportEvent } from '../../../types/consumed-headset-events';
+import DeviceInfo, { PartialHIDDevice } from '../../../types/device-info';
 import { isCefHosted } from '../../../utils';
-
-const HEADSET_USAGE = 0x0005;
-const HEADSET_USAGE_PAGE = 0x000b;
-const VENDOR_ID = 0x340b;
-const BT100USeries = [0x0001];
-const CMEDIASeries = [0x0020, 0x0022];
-const DECTSeries = [0x0014];
+import { webhidConsent, IDevice, DeviceSignalType, createDeviceManager } from '@vbet/webhid-sdk';
 
 export default class VBetService extends VendorImplementation {
   private static instance: VBetService;
 
-  public pendingConversationId: string;
-  public activeConversationId: string;
+  private activeConversationId: string;
+  private pendingConversationId: string;
 
-  private _deviceInfo: DeviceInfo = null;
-  private activeDevice: any;
-  private deviceCmds: any = null;
-  private inputReportReportId: null | number = null;
-  private lastByte = 0;
+  private _deviceInfo: DeviceInfo | null = null;
+  private activeDevice: IDevice | null = null;
   vendorName = 'VBet';
 
   static getInstance (config: ImplementationConfig): VBetService {
@@ -41,50 +31,7 @@ export default class VBetService extends VendorImplementation {
 
   deviceLabelMatchesVendor (label: string): boolean {
     const lowerLabel = label.toLowerCase();
-    return ['vt','340b'].some((searchVal) => lowerLabel.includes(searchVal));
-  }
-
-  setDeviceAttrs (pid: number): void {
-    if (BT100USeries.includes(pid)) {
-      this.deviceCmds = {
-        ring: [0x2, 0x2, 0x1],
-        offHook: [0x2, 0x2, 0x3],
-        onHook: [0x2, 0x2, 0x0],
-        muteOn: [0x3, 0x1, 0x0],
-        muteOff: [0x3, 0x0, 0x0],
-      };
-      this.inputReportReportId = 0x08;
-    } else if (CMEDIASeries.includes(pid)) {
-      this.deviceCmds = {
-        ring: [0x6, 0x1, 0x0],
-        offHook: [0x6, 0x2, 0x0],
-        onHook: [0x6, 0x0, 0x0],
-        muteOn: [0x3, 0x1, 0x0],
-        muteOff: [0x3, 0x0, 0x0],
-      };
-      this.inputReportReportId = 0x01;
-    } else if (DECTSeries.includes(pid)) {
-      this.deviceCmds = {
-        ring: [0x2, 0x2, 0x2, 0x1],
-        offHook: [0x2, 0x1, 0x0],
-        onHook: [0x2, 0x0, 0x0],
-        muteOn: [0x2, 0x2, 0x1],
-        muteOff: [0x2, 0x2, 0x0],
-        setMode: [0x2, 0x2, 0x2, 0x2, 0x2, 0x2, 0, 0],
-      };
-      this.inputReportReportId = 0x01;
-    } else if (pid >= 0x0040 && pid <= 0x0083) {
-      this.deviceCmds = {
-        ring: [0x6, 0x1, 0x0],
-        offHook: [0x6, 0x2, 0x0],
-        onHook: [0x6, 0x0, 0x0],
-        muteOn: [0x6, 0x4, 0x0],
-        muteOff: [0x6, 0x5, 0x0],
-      };
-      this.inputReportReportId = 0x05;
-    } else {
-      this.logger.error('not recognized device');
-    }
+    return ['vt', '340b'].some((searchVal) => lowerLabel.includes(searchVal));
   }
 
   async connect (originalDeviceLabel: string): Promise<void> {
@@ -92,288 +39,161 @@ export default class VBetService extends VendorImplementation {
       this.changeConnectionStatus({ isConnected: this.isConnected, isConnecting: true });
     }
     const deviceLabel = originalDeviceLabel.toLowerCase();
-    const deviceList = await (window.navigator as any).hid.getDevices();
+    let dev = null;
+    const deviceList: PartialHIDDevice[] = await (window.navigator as any).hid.getDevices();
     deviceList.forEach((device) => {
-      if (!this.activeDevice) {
+      if (!dev) {
         if (deviceLabel.includes(device?.productName?.toLowerCase())) {
-          for (const collection of device.collections) {
-            if (collection.usage === HEADSET_USAGE && collection.usagePage === HEADSET_USAGE_PAGE) {
-              this.setDeviceAttrs(device.productId);
-              this.activeDevice = device;
-              break;
-            }
-          }
+          dev = device;
         }
       }
     });
-    if (!this.activeDevice) {
-      try {
-        this.activeDevice = await new Promise((resolve, reject) => {
+
+    try {
+      if (dev) {
+        this.activeDevice = await createDeviceManager(dev);
+      } else {
+        const dev = await new Promise((resolve, reject) => {
+          const productId = this.deductProductId(originalDeviceLabel);
           const waiter = setTimeout(reject, 30000);
-          this.requestWebHidPermissions(async () => {
-            const productId = this.deductProductId(originalDeviceLabel);
-            const filters = [{ usage: HEADSET_USAGE, usagePage: HEADSET_USAGE_PAGE, vendorId: VENDOR_ID, productId: productId || undefined }];
-            await (window.navigator as any).hid.requestDevice({ filters });
-            clearTimeout(waiter);
-            const deviceList = await (window.navigator as any).hid.getDevices();
-            let bFind = false;
-            deviceList.forEach((device) => {
-              if (deviceLabel.includes(device?.productName?.toLowerCase())) {
-                for (const collection of device.collections) {
-                  if (
-                    collection.usage === HEADSET_USAGE &&
-                    collection.usagePage === HEADSET_USAGE_PAGE
-                  ) {
-                    bFind = true;
-                    this.setDeviceAttrs(device.productId);
-                    resolve(device);
-                    break;
-                  }
-                }
-              }
-            });
-            if (!bFind) {
-              reject();
-            }
+          this.requestWebHidPermissions(() => {
+            webhidConsent({
+              productId: productId ? productId : undefined,
+            })
+              .then((res) => {
+                resolve(res);
+                clearTimeout(waiter);
+              })
+              .catch((err) => {
+                reject(err);
+              });
           });
         });
-      } catch (error) {
-        this.isConnecting &&
-          this.changeConnectionStatus({ isConnected: this.isConnected, isConnecting: false });
-        this.logger.error('The selected device was not granted WebHID permissions');
-        return;
+        this.activeDevice = await createDeviceManager(dev);
       }
+    } catch (error) {
+      this.isConnecting &&
+        this.changeConnectionStatus({ isConnected: this.isConnected, isConnecting: false });
+      this.logger.error('The selected device was not granted WebHID permissions');
+      return;
     }
 
-
-    !this.activeDevice.opened && await this.activeDevice.open();
-
-
-    this.logger.debug(`device input reportId ${this.inputReportReportId}`);
-    this.activeDevice.addEventListener('inputreport', (event: PartialInputReportEvent) => {
-      if (event.reportId !== this.inputReportReportId) {
-        return;
-      }
-      const value = event.data.getUint8(0);
-      this.processBtnPress(value);
-    });
     this._deviceInfo = {
       ProductName: this.activeDevice.productName,
     };
 
-    if (this.isConnecting && !this.isConnected) {
-      this.changeConnectionStatus({ isConnected: true, isConnecting: false });
+    this.activeDevice.subscribe(this.processBtnPress);
+    
+    this.changeConnectionStatus({ isConnected: true, isConnecting: false });
+  }
+
+  processBtnPress = (signal:DeviceSignalType):void => {
+    switch (signal) {
+    case DeviceSignalType.ACCEPT_CALL:
+      if (this.pendingConversationId) {
+        this.answerCall(this.pendingConversationId);
+        this.deviceAnsweredCall({
+          name: 'OffHook',
+          conversationId: this.activeConversationId,
+        });
+      } else {
+        this.logger.error('No call to be answered');
+      }
+      break;
+    case DeviceSignalType.END_CALL:
+      if (this.activeConversationId) {
+        const id = this.activeConversationId;
+        this.endCall(id);
+        this.deviceEndedCall({
+          name: 'OnHook',
+          conversationId: id,
+        });
+      } else {
+        this.logger.error('No call to be terminated');
+      }
+      break;
+    case DeviceSignalType.MUTE_CALL:
+    case DeviceSignalType.UNMUTE_CALL:
+      if (this.activeConversationId) {
+        this.setMute(signal===DeviceSignalType.MUTE_CALL);
+        this.deviceMuteChanged({
+          isMuted: this.isMuted,
+          name: this.isMuted ? 'CallMuted' : 'CallUnmuted',
+          conversationId: this.activeConversationId,
+        });
+      } else {
+        this.logger.error('No call to be muted');
+      }
+      break;
+    case DeviceSignalType.REJECT_CALL:
+      if (this.pendingConversationId) {
+        this.rejectCall(this.pendingConversationId);
+        this.deviceRejectedCall({
+          name: 'Reject',
+          conversationId: this.pendingConversationId,
+        });
+      } else {
+        this.logger.error('No call to be rejected');
+      }
+      break;
     }
   }
 
   async disconnect (): Promise<void> {
-    if (this.isConnected || this.isConnecting) {
-      this.changeConnectionStatus({ isConnected: false, isConnecting: false });
-    }
-    if (this.activeDevice) {
-      await this.activeDevice.close();
-      this.activeDevice = null;
-      this._deviceInfo = null;
-      this.inputReportReportId = 0;
-      this.isMuted = false;
-    }
-  }
-
-  async processBtnPress (value: number): Promise<void> {
-    if (!this.activeDevice) {
-      this.logger.error('do not have active device');
-      return;
-    }
-    if (BT100USeries.includes(this.activeDevice.productId)) {
-      switch (value) {
-      case 0x04:
-        await this.answerCallFromDevice();
-        break;
-      case 0x10:
-        await this.rejectCallFromDevice();
-        break;
-      case 0x00:
-        await this.endCallFromDevice();
-        break;
-      case 0x0c:
-        await this.setMuteFromDevice(!this.isMuted);
-        break;
-      }
-    }
-    if (CMEDIASeries.includes(this.activeDevice.productId)) {
-      switch (value) {
-      case 0x01:
-        this.lastByte !== 0x09 && await this.answerCallFromDevice();
-        break;
-      case 0x00:
-        if (this.lastByte === 0x08) {
-          await this.setMuteFromDevice(!this.isMuted);
-        } else {
-          await this.endCallFromDevice();
-        }
-        break;
-      case 0x14:
-        await this.setMuteFromDevice(!this.isMuted);
-        break;
-      }
-    }
-    if (this.activeDevice.productId >= 0x0040 && this.activeDevice.productId <= 0x0083) {
-      switch (value) {
-      case 0x20:
-        await this.answerCallFromDevice();
-        break;
-      case 0x08:
-        await this.rejectCallFromDevice();
-        break;
-      case 0x00:
-        await this.endCallFromDevice();
-        break;
-      case 0x01:
-        await this.setMuteFromDevice(false);
-        break;
-      case 0x05:
-        await this.setMuteFromDevice(true);
-        break;
-      }
-    }
-    if (DECTSeries.includes(this.activeDevice.productId)) {
-      switch (value) {
-      case 0x02:
-        await this.answerCallFromDevice();
-        break;
-      case 0x00:
-        await this.endCallFromDevice();
-        break;
-      case 0x03:
-        await this.setMuteFromDevice(true);
-        break;
-      case 0x04:
-        await this.setMuteFromDevice(false);
-        break;
-      }
-    }
-    this.lastByte = value;
+    this.changeConnectionStatus({ isConnected: false, isConnecting: false });
+    this.activeDevice && this.activeDevice.unsubscribe();
+    this.activeDevice = null;
+    this._deviceInfo = null;
+    this.isMuted = false;
   }
 
   async incomingCall (callInfo: CallInfo): Promise<void> {
     this.pendingConversationId = callInfo.conversationId;
-    if (DECTSeries.includes(this.activeDevice.productId)) {
-      await this.sendOpToDevice('setMode');
-    }
-    await this.sendOpToDevice('ring');
+    this.activeDevice.ring();
   }
 
   async outgoingCall (callInfo: CallInfo): Promise<void> {
-    this.pendingConversationId = callInfo.conversationId;
-    if (DECTSeries.includes(this.activeDevice.productId)) {
-      await this.sendOpToDevice('setMode');
-    }
-    await this.sendOpToDevice('offHook');
+    this.activeConversationId = callInfo.conversationId;
+    this.activeDevice.offHook();
   }
 
   async answerCall (conversationId: string, autoAnswer?: boolean): Promise<void> {
-    if(!conversationId){
-      return;
-    }else {
-      if (autoAnswer) {
-        await this.sendOpToDevice('ring');
-        await this.sendOpToDevice('offHook');
-      } else {
-        await this.sendOpToDevice('offHook');
-        this.pendingConversationId = null;
-      }
+    if (this.pendingConversationId === conversationId || autoAnswer) {
       this.activeConversationId = conversationId;
-    }
-  }
-
-  async answerCallFromDevice (): Promise<void> {
-    await this.answerCall(this.pendingConversationId, false);
-    if (this.activeConversationId) {
-      this.deviceAnsweredCall({
-        name: 'OffHook',
-        conversationId: this.activeConversationId,
-      });
+      this.pendingConversationId = '';
+      this.activeDevice.offHook();
     } else {
       this.logger.error('no call to be answered');
     }
   }
 
-  async rejectCall (): Promise<void> {
-    if (this.pendingConversationId) {
-      this.pendingConversationId = null;
-      await this.sendOpToDevice('onHook');
+  async rejectCall (conversationId: string): Promise<void> {
+    if (conversationId === this.pendingConversationId) {
+      this.pendingConversationId = '';
+      this.activeDevice.onHook();
     } else {
       this.logger.error('no call to be rejected');
     }
   }
 
-  async rejectCallFromDevice (): Promise<void> {
-    this.deviceRejectedCall({
-      name: 'Reject',
-      conversationId: this.pendingConversationId,
-    });
-    await this.rejectCall();
-  }
-
-  async endCall (conversationId: string, hasOtherActiveCalls: boolean): Promise<void> {
-    if (hasOtherActiveCalls) {
-      return;
-    } else {
-      if (conversationId === this.activeConversationId || this.pendingConversationId) {
-        this.activeConversationId = null;
-        this.pendingConversationId = null;
-        await this.sendOpToDevice('onHook');
-      } else {
-        this.logger.error('no call to be ended');
-      }
-    }
-  }
-
-  async endCallFromDevice (): Promise<void> {
-    if (this.activeConversationId || this.pendingConversationId) {
-      await this.sendOpToDevice('onHook');
-      this.deviceEndedCall({
-        name: 'OnHook',
-        conversationId: this.activeConversationId ? this.activeConversationId : this.pendingConversationId,
-      });
-      this.activeConversationId = null;
-      this.pendingConversationId = null;
+  async endCall (conversationId: string): Promise<void> {
+    if (conversationId === this.activeConversationId) {
+      this.activeConversationId = '';
+      this.pendingConversationId = '';
+      this.activeDevice.onHook();
     } else {
       this.logger.error('no call to be ended');
     }
   }
 
   async endAllCalls (): Promise<void> {
-    if (this.activeConversationId || this.pendingConversationId) {
-      this.activeConversationId = null;
-      this.pendingConversationId = null;
-      await this.sendOpToDevice('onHook');
-    }
+    this.activeConversationId = '';
+    this.pendingConversationId = '';
+    this.activeDevice.onHook();
   }
 
   async setMute (value: boolean): Promise<void> {
-    if (value) {
-      await this.sendOpToDevice('muteOn');
-    } else {
-      await this.sendOpToDevice('muteOff');
-    }
     this.isMuted = value;
-  }
-
-  async setMuteFromDevice (value: boolean): Promise<void> {
-    await this.setMute(value);
-    this.deviceMuteChanged({
-      isMuted: this.isMuted,
-      name: this.isMuted ? 'CallMuted' : 'CallUnmuted',
-      conversationId: this.activeConversationId,
-    });
-  }
-
-  async sendOpToDevice (
-    value: 'ring' | 'onHook' | 'offHook' | 'muteOn' | 'muteOff' | 'setMode'
-  ): Promise<void> {
-    const data = new Uint8Array(this.deviceCmds[value]);
-    this.logger.debug(`send to dev ${value}`);
-    await this.activeDevice.sendReport(data[0], data.slice(1, data.length));
+    this.isMuted ? this.activeDevice.muteOn() : this.activeDevice.muteOff();
   }
 }


### PR DESCRIPTION
Hey guys, previously the supported device's productIds were hard-coded and so were the command masks , as we rolled out some new device models the code was not applicable for the new devices, thereby we extracted those logic into a package so that we can maintain it there for convenient purpose.  