### PR TITLE
STREAM-1586: Fix headset.test.ts crash due to missing structuredClone in jsdom

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [STREAM-619](https://inindca.atlassian.net/browse/STREAM-619) - Removed pipeline infrastructure from open-source.
 ## Added
 * [STREAM-881](https://inindca.atlassian.net/browse/STREAM-881) - Generate a test report in JUnit.xml format
+## Fixed
+* [STREAM-1586](https://inindca.atlassian.net/browse/STREAM-1586) - Fix test failures due to missing value from imported dependency
 
 # [v2.5.6](https://github.com/purecloudlabs/softphone-vendor-headsets/compare/v2.5.5...v2.5.6)
 ## Changed

--- a/react-app/src/setupTests.ts
+++ b/react-app/src/setupTests.ts
@@ -3,3 +3,6 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Polyfill structuredClone for jsdom environment (not implemented in jsdom)
+global.structuredClone = global.structuredClone ?? ((val) => JSON.parse(JSON.stringify(val)));


### PR DESCRIPTION
The Jabra SDK calls structuredClone() during async initialization, which doesn't exist in our jsdom test environment. This crashes the Jest worker. Add a structuredClone polyfill to setupTests.ts