### PR TITLE
[STREAM-1867] - Added optional chaining to hostedContext and removed waitForHostedContext function as it has potential to be an endless loop

### DIFF
--- a/react-app/src/library/services/vendor-implementations/jabra/jabra-native/jabra-native.test.ts
+++ b/react-app/src/library/services/vendor-implementations/jabra/jabra-native/jabra-native.test.ts
@@ -68,52 +68,14 @@ describe('JabraNativeService', () => {
       expect(jabraNativeService.headsetState.offHook).toBe(false);
     });
 
-    it('should call waitForHostedContext if not already hosted', () => {
-      hostedContext._isHosted = false;
-      jest.spyOn(utils, 'isCefHosted').mockReturnValue(true);
-
-      const setupNativeHandlersSpy = jest.spyOn(JabraNativeService.prototype as any, 'setupNativeHandlers');
-      const waitForHostedContextSpy = jest.spyOn(JabraNativeService.prototype as any, 'waitForHostedContext');
-
-      JabraNativeService.getInstance({ logger: console, createNew: true, hostedContext });
-
-      expect(setupNativeHandlersSpy).not.toHaveBeenCalled();
-      expect(waitForHostedContextSpy).toHaveBeenCalled();
-    })
-
     it('should call setupNativeHandlers if already hosted', () => {
       jest.spyOn(utils, 'isCefHosted').mockReturnValue(true);
 
       const setupNativeHandlersSpy = jest.spyOn(JabraNativeService.prototype as any, 'setupNativeHandlers');
-      const waitForHostedContextSpy = jest.spyOn(JabraNativeService.prototype as any, 'waitForHostedContext');
 
       JabraNativeService.getInstance({ logger: console, createNew: true, hostedContext });
 
       expect(setupNativeHandlersSpy).toHaveBeenCalled();
-      expect(waitForHostedContextSpy).not.toHaveBeenCalled();
-    })
-  })
-
-  describe('waitForHostedContext', () => {
-    afterEach(() => {
-      jest.useRealTimers();
-    })
-    it('should call setupNativeHandlers after 500 ms timeout and isHosted', async () => {
-      jest.useFakeTimers();
-      jabraNativeService['waitForHostedContext']();
-      const setupNativeHandlersSpy = jabraNativeService['setupNativeHandlers'] = jest.fn();
-      await flushPromises();
-      jest.advanceTimersByTime(600);
-      expect(setupNativeHandlersSpy).toHaveBeenCalled();
-    })
-    it('should call waitForHostedContext after 500 ms timeout and !isHosted', async () => {
-      hostedContext._isHosted = false;
-      jest.useFakeTimers();
-      jabraNativeService['waitForHostedContext']();
-      const waitForHostedContextSpy = jabraNativeService['waitForHostedContext'] = jest.fn();
-      await flushPromises();
-      jest.advanceTimersByTime(600);
-      expect(waitForHostedContextSpy).toHaveBeenCalled();
     })
   })
 
@@ -131,7 +93,7 @@ describe('JabraNativeService', () => {
 
       expect(jabraNativeService.isSupported()).toBeFalsy();
     });
-    
+
     it('should not be supported if not cef' , () => {
       jest.spyOn(utils, 'isCefHosted').mockReturnValue(false);
       jabraNativeService.cefSupportsJabra = false;

--- a/react-app/src/library/services/vendor-implementations/jabra/jabra-native/jabra-native.ts
+++ b/react-app/src/library/services/vendor-implementations/jabra/jabra-native/jabra-native.ts
@@ -28,23 +28,9 @@ export default class JabraNativeService extends VendorImplementation {
     this.headsetState = { ringing: false, offHook: false };
     this.devices = new Map<string, DeviceInfo>();
 
-    if (isCefHosted()) {
-      if (this.config.hostedContext.isHosted()) {
-        this.setupNativeHandlers();
-      } else {
-        this.waitForHostedContext();
-      }
+    if (isCefHosted() && this.config.hostedContext?.isHosted()) {
+      this.setupNativeHandlers();
     }
-  }
-
-  private waitForHostedContext () {
-    setTimeout(() => {
-      if (this.config.hostedContext.isHosted()) {
-        this.setupNativeHandlers()
-      } else {
-        this.waitForHostedContext();
-      }
-    }, 500);
   }
 
   private setupNativeHandlers () {

--- a/react-app/src/library/services/vendor-implementations/plantronics/plantronics.test.ts
+++ b/react-app/src/library/services/vendor-implementations/plantronics/plantronics.test.ts
@@ -661,6 +661,40 @@ describe('PlantronicsService', () => {
       });
     });
 
+    it('logs an error message upon failure to reset mute when ending a call', async () => {
+      const setMuteSpy = jest.spyOn(plantronicsService, 'setMute');
+      plantronicsService.logger.info = jest.fn();
+      plantronicsService.isConnected = true;
+      jest.spyOn(plantronicsService, '_fetch').mockImplementation((url): Promise<any> => {
+        if (url.includes('/CallServices/MuteCall')) {
+          return buildMockFetch(responses.CallServices.MuteCall.unmute, true);
+        }
+
+        if (url.includes('/CallServices/ResumeCall')) {
+          return buildMockFetch(responses.CallServices.ResumeCall.default, true);
+        }
+
+        if (url.includes('/CallServices/TerminateCall')) {
+          return buildMockFetch(responses.CallServices.TerminateCall.default, true);
+        }
+
+        return buildMockFetch({}, true);
+      });
+
+      const conversationId = 'myConvoId12345';
+      const callId = 555123;
+      plantronicsService.callMappings = {
+        [conversationId]: callId,
+        [callId]: conversationId
+      };
+
+      setMuteSpy.mockRejectedValue('Unable to mute before ending call');
+
+      await plantronicsService.endCall(conversationId);
+
+      expect(plantronicsService.logger.info).toHaveBeenCalledWith('Plantronics: failed to reset mute before ending call', { conversationId, error: 'Unable to mute before ending call' });
+    });
+
     it('resets hold and emits deviceHoldStatusChanged when ending a call', async () => {
       const setHoldSpy = jest.spyOn(plantronicsService, 'setHold');
       const deviceHoldStatusChangedSpy = jest.spyOn(plantronicsService, 'deviceHoldStatusChanged');
@@ -696,6 +730,40 @@ describe('PlantronicsService', () => {
         name: 'CallEndHoldReset',
         conversationId
       });
+    });
+
+    it('logs an error message upon failure to reset hold when ending a call', async () => {
+      const setMuteSpy = jest.spyOn(plantronicsService, 'setHold');
+      plantronicsService.logger.info = jest.fn();
+      plantronicsService.isConnected = true;
+      jest.spyOn(plantronicsService, '_fetch').mockImplementation((url): Promise<any> => {
+        if (url.includes('/CallServices/MuteCall')) {
+          return buildMockFetch(responses.CallServices.MuteCall.unmute, true);
+        }
+
+        if (url.includes('/CallServices/ResumeCall')) {
+          return buildMockFetch(responses.CallServices.ResumeCall.default, true);
+        }
+
+        if (url.includes('/CallServices/TerminateCall')) {
+          return buildMockFetch(responses.CallServices.TerminateCall.default, true);
+        }
+
+        return buildMockFetch({}, true);
+      });
+
+      const conversationId = 'myConvoId12345';
+      const callId = 555123;
+      plantronicsService.callMappings = {
+        [conversationId]: callId,
+        [callId]: conversationId
+      };
+
+      setMuteSpy.mockRejectedValue('Unable to hold before ending call');
+
+      await plantronicsService.endCall(conversationId);
+
+      expect(plantronicsService.logger.info).toHaveBeenCalledWith('Plantronics: failed to reset hold before ending call', { conversationId, error: 'Unable to hold before ending call' });
     });
 
     it('resets mute and hold before terminating the call', async () => {


### PR DESCRIPTION
An issue was reported recently where media helper running in the desktop app would crash.  The error message "reading `isHosted` of undefined" could be seen meaning that `hostedContext` was not present at the time of checking.  Adding in optional chaining in the chance of `hostedContext` not being defined to hopefully fix this issue