### PR TITLE
[STREAM-2242] - Fixing issue with Jabra on desktop app and Poly WebHID on Mac desktop

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,9 +3,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keepa Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [Unreleased](https://github.com/purecloudlabs/softphone-vendor-headsets/compare/v3.0.3...HEAD)
+# [Unreleased](https://github.com/purecloudlabs/softphone-vendor-headsets/compare/v4.0.0...HEAD)
 ## Added
-* [STREAM-1048](https://inindca.atlassian.net/browse/STREAM-1688) - Added additional logging to hopefully help with debugging in the future
+* [no-jira] - Functionality for VBeT to hold and unhold calls
+## Fixed
+* [STREAM-2242](https://inindca.atlassian.net/browse/STREAM-2242) - Fixing issues that were found during Bughunt.  One was a regression for the Jabra implementations so they can be used on desktop apps, the other was an issue around trying to use Poly WebHID on a Mac desktop app that does not support WebHID, now we fall back to legacy Plantronics
+
+# [v4.0.0](https://github.com/purecloudlabs/softphone-vendor-headsets/compare/v3.0.3...v4.0.0)
+## Added
+* [STREAM-1048](https://inindca.atlassian.net/browse/STREAM-1688) - Added additional logging to help with debugging in the future
 * [STREAM-1795](https://inindca.atlassian.net/browse/STREAM-1795) - Added in new implementation for Poly HP devices that use WebHID as opposed to secondary application
 
 # [v3.0.3](https://github.com/purecloudlabs/softphone-vendor-headsets/compare/v3.0.2...v3.0.3)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "softphone-vendor-headsets",
-  "version": "3.0.3",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "softphone-vendor-headsets",
-      "version": "3.0.3",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "@gnaudio/jabra-js": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "softphone-vendor-headsets",
-  "version": "3.0.3",
+  "version": "4.0.0",
   "author": "Genesys",
   "license": "MIT",
   "cjs": "dist/cjs/src/library/index.js",

--- a/react-app/src/library/services/headset.ts
+++ b/react-app/src/library/services/headset.ts
@@ -42,10 +42,10 @@ export default class HeadsetService {
     this.headsetEvents$ = this._headsetEvents$.asObservable();
 
     this.logger = config.logger || console;
-    this.plantronics = PlantronicsService.getInstance({ logger: this.logger, appName: config.appName, useNewPolyImplementation: config.useNewPolyImplementation });
-    this.hp = HpService.getInstance({ logger: this.logger, appName: config.appName, useNewPolyImplementation: config.useNewPolyImplementation });
-    this.jabraNative = JabraNativeService.getInstance({ logger: this.logger });
-    this.jabra = JabraService.getInstance({ logger: this.logger });
+    this.plantronics = PlantronicsService.getInstance({ logger: this.logger, appName: config.appName, hostedContext: config.hostedContext, useNewPolyImplementation: config.useNewPolyImplementation });
+    this.hp = HpService.getInstance({ logger: this.logger, appName: config.appName, hostedContext: config.hostedContext, useNewPolyImplementation: config.useNewPolyImplementation });
+    this.jabraNative = JabraNativeService.getInstance({ logger: this.logger, hostedContext: config.hostedContext, useWebHidOnDesktopJabra: config.useWebHidOnDesktopJabra });
+    this.jabra = JabraService.getInstance({ logger: this.logger, hostedContext: config.hostedContext, useWebHidOnDesktopJabra: config.useWebHidOnDesktopJabra });
     this.sennheiser = SennheiserService.getInstance({ logger: this.logger });
     this.yealink = YealinkService.getInstance({ logger: this.logger, hostedContext: config.hostedContext, useWebHidOnDesktopYealink: config.useWebHidOnDesktopYealink });
     this.vbet = VBetService.getInstance({ logger: this.logger, hostedContext: config.hostedContext, useWebHidOnDesktopVbet: config.useWebHidOnDesktopVbet });
@@ -64,7 +64,6 @@ export default class HeadsetService {
 
   get implementations (): VendorImplementation[] {
     const implementations = [
-
       this.sennheiser,
       this.plantronics,
       this.hp,

--- a/react-app/src/library/services/vendor-implementations/hp/hp.test.ts
+++ b/react-app/src/library/services/vendor-implementations/hp/hp.test.ts
@@ -2,7 +2,6 @@
 import "whatwg-fetch";
 import 'regenerator-runtime';
 import { mockLogger, eventValidation } from "../../../test-utils";
-import { UpdateReasons } from '../../../types/headset-states';
 import DeviceInfo from "../../../types/device-info";
 import HpService from "./hp";
 import {
@@ -43,12 +42,40 @@ describe('HpService', () => {
 
   describe('isSupported', () => {
     it('should return false if the proper values are not met', () => {
-      expect(hpService.isSupported()).toBe(undefined);
+      expect(hpService.isSupported()).toBe(false);
     });
 
     it('should return true if the proper values are met', () => {
       hpService.config = { logger: console, useNewPolyImplementation: true };
       expect(hpService.isSupported()).toBe(true);
+    });
+
+    it('should return true if hosted and supports WebHID', () => {
+      hpService.config = {
+        logger: console,
+        useNewPolyImplementation: true,
+        hostedContext: {
+          supportsWebHid: () => { return true; }
+        }
+      };
+
+      (window as any)._HostedContextFunctions = true;
+
+      expect(hpService.isSupported()).toBe(true);
+    });
+
+    it('should return false if hosted and does not support WebHID', () => {
+      hpService.config = {
+        logger: console,
+        useNewPolyImplementation: true,
+        hostedContext: {
+          supportsWebHid: () => { return false; }
+        }
+      };
+
+      expect(hpService.isSupported()).toBe(false);
+
+      (window as any)._HostedContextFunctions = undefined;
     });
   });
 

--- a/react-app/src/library/services/vendor-implementations/hp/hp.ts
+++ b/react-app/src/library/services/vendor-implementations/hp/hp.ts
@@ -40,13 +40,10 @@ export default class HpService extends VendorImplementation {
 
   isSupported (): boolean {
     if (this.config.useNewPolyImplementation) {
-      console.log('mMoo: FT true');
       if (isCefHosted()) {
-        console.log('mMoo: is hosted');
         return this.config.hostedContext?.supportsWebHid();
       }
 
-      console.log('mMoo: is not hosted', (window.navigator as any).hid);
       return !!(window.navigator as any).hid;
     }
 

--- a/react-app/src/library/services/vendor-implementations/hp/hp.ts
+++ b/react-app/src/library/services/vendor-implementations/hp/hp.ts
@@ -3,6 +3,7 @@ import DeviceInfo from '../../../types/device-info';
 import { CallInfo } from '../../../types/call-info';
 import { UpdateReasons } from '../../../types/headset-states';
 import CcSdk, { CallState, SdkEvent } from '@hp/call-control-sdk';
+import { isCefHosted } from '../../../utils';
 
 const defaultAppName = 'genesys-cloud-headset-library';
 
@@ -38,7 +39,18 @@ export default class HpService extends VendorImplementation {
   }
 
   isSupported (): boolean {
-    return this.config.useNewPolyImplementation;
+    if (this.config.useNewPolyImplementation) {
+      console.log('mMoo: FT true');
+      if (isCefHosted()) {
+        console.log('mMoo: is hosted');
+        return this.config.hostedContext?.supportsWebHid();
+      }
+
+      console.log('mMoo: is not hosted', (window.navigator as any).hid);
+      return !!(window.navigator as any).hid;
+    }
+
+    return false;
   }
 
   deviceLabelMatchesVendor (label: string): boolean {

--- a/react-app/src/library/services/vendor-implementations/plantronics/plantronics.test.ts
+++ b/react-app/src/library/services/vendor-implementations/plantronics/plantronics.test.ts
@@ -89,6 +89,34 @@ describe('PlantronicsService', () => {
       plantronicsService.config = { logger: console, useNewPolyImplementation: true };
       expect(plantronicsService.isSupported()).toBe(false);
     });
+
+    it('should return true if hosted and does not support WebHID', () => {
+      plantronicsService.config = {
+        logger: console,
+        useNewPolyImplementation: false,
+        hostedContext: {
+          supportsWebHid: () => { return false; }
+        }
+      };
+
+      (window as any)._HostedContextFunctions = true;
+
+      expect(plantronicsService.isSupported()).toBe(true);
+    });
+
+    it('should return false if hosted and does support WebHID', () => {
+      plantronicsService.config = {
+        logger: console,
+        useNewPolyImplementation: true,
+        hostedContext: {
+          supportsWebHid: () => { return true; }
+        }
+      };
+
+      expect(plantronicsService.isSupported()).toBe(false);
+
+      (window as any)._HostedContextFunctions = undefined;
+    });
   });
 
   describe('deviceName', () => {

--- a/react-app/src/library/services/vendor-implementations/plantronics/plantronics.ts
+++ b/react-app/src/library/services/vendor-implementations/plantronics/plantronics.ts
@@ -5,6 +5,7 @@ import browserama from 'browserama';
 import DeviceInfo from '../../../types/device-info';
 import { CallInfo } from '../../../types/call-info';
 import { UpdateReasons } from '../../../types/headset-states';
+import { isCefHosted } from '../../../utils';
 
 const defaultAppName = 'genesys-cloud-headset-library';
 
@@ -43,7 +44,15 @@ export default class PlantronicsService extends VendorImplementation {
   }
 
   isSupported (): boolean {
-    return !this.config.useNewPolyImplementation;
+    if (this.config.useNewPolyImplementation) {
+      if (isCefHosted()) {
+        return !this.config.hostedContext?.supportsWebHid();
+      }
+
+      return !(window.navigator as any).hid;
+    }
+
+    return true;
   }
 
   private _createCallMapping (conversationId: string): number {


### PR DESCRIPTION
During testing, we found two main issues:
1.) A regression with Jabra and Jabra Native that prevents WebHID functionality for desktop app
2.) An issue around Poly WebHID on Mac desktop app where consuming app attempted to prompt for WebHID permissions despite being unsupported